### PR TITLE
Fix checkbox "Remember me" on login page

### DIFF
--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -37,7 +37,7 @@
                     </div>
                     <div class="row">
                         <div class="col-xs-7 p-t-5">
-                            <input class="filled-in chk-col-pink" name="_rememberme" type="checkbox" id="rememberme">
+                            <input class="filled-in chk-col-pink" name="_remember_me" type="checkbox" id="rememberme">
                             <label for="rememberme">{{ "security.login.remember_me"|trans({}, "FOSUserBundle") }}</label>
                         </div>
                         <div class="col-xs-5">


### PR DESCRIPTION
Underscore is missing into name of checkbox "Remember me" on login page.